### PR TITLE
add direnv to brewfile

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -24,6 +24,7 @@ brew "git-crypt"
 brew "pinentry-mac"
 brew "gnupg"
 brew "python"
+brew "direnv"
 
 
 cask "google-chrome"


### PR DESCRIPTION
direnv is an extension for your shell. It augments existing shells with a new feature that can load and unload environment variables depending on the current directory.